### PR TITLE
Fixed Bug where last file in the lcov parse would not get added to the list. 

### DIFF
--- a/coverage.go
+++ b/coverage.go
@@ -139,6 +139,8 @@ func (l Parser) processLcov() (Report, error) {
 		}
 
 	}
+	// Add last file
+	report.Files = append(report.Files, fileReport)
 	return report, nil
 }
 

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -17,6 +17,8 @@ func TestLCOV(t *testing.T) {
 	assert.Equal(t, 1695, report.TotalFunctions)
 	assert.Equal(t, 2798, report.CoveredLines)
 	assert.Equal(t, 6395, report.TotalLines)
+	assert.Equal(t, 182, len(report.Files))
+
 }
 
 func TestCobertura(t *testing.T) {


### PR DESCRIPTION
Noticed this bug while working with the library. I've added a test case and fixed the issue